### PR TITLE
CMake: fix boost target use

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,15 @@ add_library(${PROJECT_NAME} SHARED ${${PROJECT_NAME}_SOURCES}
 target_include_directories(
   ${PROJECT_NAME} PUBLIC $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 target_link_libraries(${PROJECT_NAME} PUBLIC Eigen3::Eigen qpOASES::qpOASES
-                                             CDD::CDD Boost::Boost)
+                                             CDD::CDD)
+modernize_target_link_libraries(
+  ${PROJECT_NAME}
+  SCOPE
+  PUBLIC
+  TARGETS
+  Boost::Boost
+  INCLUDE_DIRS
+  ${BOOST_INCLUDEDIR})
 
 if(BUILD_WITH_CLP)
   target_link_libraries(${PROJECT_NAME} PUBLIC CoinUtils::CoinUtils CLP::CLP)


### PR DESCRIPTION
fix on 20.04:

CMake Error at CMakeLists.txt:103 (add_library):
Target "hpp-centroidal-dynamics" links to target "Boost::Boost" but the target was not found.  Perhaps a find_package() call is missing for an IMPORTED target, or an ALIAS target is missing?